### PR TITLE
added link to tee spring GCL storefront in navbar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,11 @@
           <li class="nav-item">
             <a class="nav-link" href="#sponsors-partners">Sponsors and Partners</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://teespring.com/stores/girlscodelincoln" target="_blank" rel="noopener">
+              Merchandise
+            </a>
+          </li>
           <!-- donate button to show on larger screen widths - shows right of all other nav links -->
           <li class="nav-item d-none d-md-block">
             <a


### PR DESCRIPTION
closes #55 

desktop:
![image](https://user-images.githubusercontent.com/22859824/52615988-a7e23700-2e5c-11e9-8633-7964a61510ee.png)

tablet (ipad):
![image](https://user-images.githubusercontent.com/22859824/52616111-f7c0fe00-2e5c-11e9-91cb-692f740b908c.png)

mobile (pixel2):
![image](https://user-images.githubusercontent.com/22859824/52616118-04455680-2e5d-11e9-88a3-7420ec56e29a.png)

Clicking link routes to Teespring storefront (please feel free to critique the storefront as well) https://teespring.com/stores/girlscodelincoln