### PR TITLE
51 contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hit CTRL-C to stop the server
 ```
 
 When you access one of these local hosts, the shell will output any local imports that are made and if they were successful.
-The contact form submissions are done through Netlify, so submissions on localhost will not work. Refer to the website's [Netlify](https://app.netlify.com/sites/girlscodelincoln/overview) to make changes to the contact form.
+The contact form submissions are done through Netlify, so submissions on localhost will not work. Refer to the website's [Netlify](https://app.netlify.com/sites/girlscodelincoln/settings/forms) to make changes to the contact form.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Available on:
 Hit CTRL-C to stop the server
 ```
 
-When you access one of these local hosts, the shell will output any local imports that are made and if they were successful
+When you access one of these local hosts, the shell will output any local imports that are made and if they were successful.
+The contact form submissions are done through Netlify, so submissions on localhost will not work. Refer to the website's [Netlify](https://app.netlify.com/sites/girlscodelincoln/overview) to make changes to the contact form.
 
 ## Deployment
 
-When any changes are made to the master branch of the [repository](https://github.com/GirlsCodeLincoln/Website), the changes are automatically deployed to [girlscodelincoln.com](http://www.girlscodelincoln.com) via [Netlify](https://www.netlify.com/)
+When any changes are made to the master branch of the [repository](https://github.com/GirlsCodeLincoln/Website), the changes are automatically deployed to [girlscodelincoln.com](http://www.girlscodelincoln.com) via [Netlify](https://app.netlify.com/sites/girlscodelincoln/overview)

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -17,6 +17,10 @@ a {
   color: #0A4BED;
 }
 
+.navbar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
 .navbar-brand img {
   height: 30px;
   max-width: 45vw;
@@ -161,7 +165,6 @@ ul.timeline > li.previous-club {
 
 #contact {
   background: linear-gradient(45deg, #7662AD 0%, #2A29B4 100%);
-  height: 100vh;
 }
 
 .cta-btn,
@@ -177,6 +180,10 @@ ul.timeline > li.previous-club {
 .cta-btn:hover, .cta-btn:focus {
   /* GCL Pink, darkened 5% */
   background-color: #D182C1;
+}
+
+footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 #social-links i {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -159,6 +159,11 @@ ul.timeline > li.previous-club {
   transform: scale(1.04);
 }
 
+#contact {
+  background: linear-gradient(45deg, #7662AD 0%, #2A29B4 100%);
+  height: 100vh;
+}
+
 .cta-btn,
 /* increase specificity so text is not white lke other nav-items */
 .navbar .nav-item .cta-btn {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -191,13 +191,18 @@ footer {
   border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
+#social-links a {
+  text-decoration: none;
+}
+
 #social-links i {
-  color: white;
+  color: black;
   transition: all 0.3s ease;
 }
 
-#social-links i:hover {
-  color: #D895CA;
+#social-links i:hover,
+#social-links i:focus {
+  color: #0A4BED;
   transform: scale(1.08);
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -251,7 +251,10 @@
       </section>
 
       <section id="contact" class="col-12 py-5">
-        <h2 class="text-center mb-5 font-weight-bold text-white">Contact</h2>
+        <div class="text-center text-white mb-5">
+          <h2 class="mb-3 font-weight-bold">Contact</h2>
+          <i>Send us a message and we will get back to you soon!</i>
+        </div>
         <form
           role="form"
           name="contact"

--- a/src/index.html
+++ b/src/index.html
@@ -252,7 +252,14 @@
 
       <section id="contact" class="col-12 py-5">
         <h2 class="text-center mb-5 font-weight-bold text-white">Contact</h2>
-        <form role="form" id="contactForm" name="contact" data-netlify="true" method="POST" class="col-10 col-lg-6 mx-auto text-white">
+        <form
+          role="form"
+          name="contact"
+          data-netlify="true"
+          netlify-honeypot="bot-field"
+          method="POST"
+          class="col-10 col-lg-6 mx-auto text-white"
+        >
           <div class="row">
             <p class="d-none">
               <label>Don’t fill this out if you're human: <input name="bot-field" /></label>

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
         </span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav ml-auto">
+        <ul class="navbar-nav ml-auto align-items-md-center">
           <li class="nav-item">
             <a class="nav-link" href="#about-us">About Us</a>
           </li>
@@ -70,6 +70,9 @@
             <a class="nav-link" href="https://teespring.com/stores/girlscodelincoln" target="_blank" rel="noopener">
               Merchandise
             </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#contact">Contact</a>
           </li>
           <!-- donate button to show on larger screen widths - shows right of all other nav links -->
           <li class="nav-item d-none d-md-block">
@@ -247,8 +250,29 @@
         </div>
       </section>
 
-      <section id="contact" class="col-12 py-5">
-        foo
+      <section id="contact" name="contact" data-netlify="true" class="col-12 py-5">
+        <h2 class="text-center mb-5 font-weight-bold text-white">Contact</h2>
+        <form role="form" id="contactForm" class="col-10 col-lg-6 mx-auto text-white">
+          <div class="row">
+            <div class="form-group col-sm-6">
+                <label for="name">Name</label>
+                <input type="text" class="form-control" id="name" placeholder="Enter name" required>
+            </div>
+            <div class="form-group col-sm-6">
+                <label for="email">Email</label>
+                <input type="email" class="form-control" id="email" placeholder="Enter email" required>
+            </div>
+          </div>
+          <div class="form-group">
+              <label for="message">Message</label>
+              <textarea id="message" class="form-control" rows="5" placeholder="Enter your message" required></textarea>
+          </div>
+          <button type="submit" id="form-submit" class="btn cta-btn float-right">
+            <i class="fas fa-paper-plane text-dark mr-2"></i>
+            Submit
+          </button>
+          <div id="msgSubmit" class="h3 text-center d-none">Message Submitted!</div>
+        </form>
       </section>
     </main>
 
@@ -257,7 +281,6 @@
         <div class="my-4">
           <h5><i class="font-weight-bold">Connect With Us</i></h5>
           <div id="social-links" class=>
-            <!-- Email icon with mailto: link injected here in JS to prevent spam -->
             <a href="https://www.instagram.com/girlscodelincoln" target="_blank" rel="noopener" aria-label="Instagram">
               <i class="fab fa-instagram fa-2x mx-2" aria-hidden="true"></i>
             </a>

--- a/src/index.html
+++ b/src/index.html
@@ -103,7 +103,6 @@
             We partner with Nebraska organizations and build in-house curriculum to teach technology, leadership, and life skills.
           </i>
         </div>
-        <!-- <hr class="col-6 hr"> -->
         <h3 class="text-center mb-4">Our Impact</h3>
         <div class="col-9 d-flex flex-row justify-content-between align-items-start mx-auto flex-wrap">
           <div class="col-xs-6 col-sm-2 d-flex flex-column align-items-center text-center">
@@ -246,6 +245,10 @@
             Want to become a Sponsor or Partner?
           </a>
         </div>
+      </section>
+
+      <section id="contact" class="col-12 py-5">
+        foo
       </section>
     </main>
 

--- a/src/index.html
+++ b/src/index.html
@@ -269,18 +269,18 @@
             </p>
             <div class="form-group col-sm-6">
                 <label for="name">Name</label>
-                <input type="text" class="form-control" id="name" name="name" placeholder="Enter name" required>
+                <input type="text" class="form-control" name="name" placeholder="Enter name" required>
             </div>
             <div class="form-group col-sm-6">
                 <label for="email">Email</label>
-                <input type="email" class="form-control" id="email" name="email" placeholder="Enter email" required>
+                <input type="email" class="form-control" name="email" placeholder="Enter email" required>
             </div>
           </div>
           <div class="form-group">
               <label for="message" name="message">Message</label>
-              <textarea id="message" name="message" class="form-control" rows="5" placeholder="Enter your message" required></textarea>
+              <textarea name="message" class="form-control" rows="5" placeholder="Enter your message" required></textarea>
           </div>
-          <button type="submit" id="form-submit" class="btn cta-btn float-right">
+          <button type="submit" class="btn cta-btn float-right">
             <i class="fas fa-paper-plane text-dark mr-2"></i>
             Submit
           </button>

--- a/src/index.html
+++ b/src/index.html
@@ -259,22 +259,21 @@
             </p>
             <div class="form-group col-sm-6">
                 <label for="name">Name</label>
-                <input type="text" class="form-control" id="name" placeholder="Enter name" required>
+                <input type="text" class="form-control" id="name" name="name" placeholder="Enter name" required>
             </div>
             <div class="form-group col-sm-6">
                 <label for="email">Email</label>
-                <input type="email" class="form-control" id="email" placeholder="Enter email" required>
+                <input type="email" class="form-control" id="email" name="email" placeholder="Enter email" required>
             </div>
           </div>
           <div class="form-group">
-              <label for="message">Message</label>
-              <textarea id="message" class="form-control" rows="5" placeholder="Enter your message" required></textarea>
+              <label for="message" name="message">Message</label>
+              <textarea id="message" name="message" class="form-control" rows="5" placeholder="Enter your message" required></textarea>
           </div>
           <button type="submit" id="form-submit" class="btn cta-btn float-right">
             <i class="fas fa-paper-plane text-dark mr-2"></i>
             Submit
           </button>
-          <div id="msgSubmit" class="h3 text-center d-none">Message Submitted!</div>
         </form>
       </section>
     </main>

--- a/src/index.html
+++ b/src/index.html
@@ -254,6 +254,9 @@
         <h2 class="text-center mb-5 font-weight-bold text-white">Contact</h2>
         <form role="form" id="contactForm" class="col-10 col-lg-6 mx-auto text-white">
           <div class="row">
+            <p class="d-none" aria-hidden="true">
+              <label>Don’t fill this out if you're human: <input name="bot-field" /></label>
+            </p>
             <div class="form-group col-sm-6">
                 <label for="name">Name</label>
                 <input type="text" class="form-control" id="name" placeholder="Enter name" required>

--- a/src/index.html
+++ b/src/index.html
@@ -288,11 +288,11 @@
       </section>
     </main>
 
-    <footer class="row py-3 bg-blue">
-      <div class="col-12 text-light text-center">
+    <footer class="row py-3 bg-grey">
+      <div class="col-12 text-black text-center">
         <div class="my-4">
           <h5><i class="font-weight-bold">Connect With Us</i></h5>
-          <div id="social-links" class=>
+          <div id="social-links">
             <a href="https://www.instagram.com/girlscodelincoln" target="_blank" rel="noopener" aria-label="Instagram">
               <i class="fab fa-instagram fa-2x mx-2" aria-hidden="true"></i>
             </a>

--- a/src/index.html
+++ b/src/index.html
@@ -252,7 +252,7 @@
 
       <section id="contact" class="col-12 py-5">
         <div class="text-center text-white mb-5">
-          <h2 class="mb-3 font-weight-bold">Contact</h2>
+          <h2 class="font-weight-bold">Contact</h2>
           <i>Send us a message and we will get back to you soon!</i>
         </div>
         <form

--- a/src/index.html
+++ b/src/index.html
@@ -250,11 +250,11 @@
         </div>
       </section>
 
-      <section id="contact" name="contact" data-netlify="true" class="col-12 py-5">
+      <section id="contact" class="col-12 py-5">
         <h2 class="text-center mb-5 font-weight-bold text-white">Contact</h2>
-        <form role="form" id="contactForm" class="col-10 col-lg-6 mx-auto text-white">
+        <form role="form" id="contactForm" name="contact" data-netlify="true" method="POST" class="col-10 col-lg-6 mx-auto text-white">
           <div class="row">
-            <p class="d-none" aria-hidden="true">
+            <p class="d-none">
               <label>Don’t fill this out if you're human: <input name="bot-field" /></label>
             </p>
             <div class="form-group col-sm-6">

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,36 +33,6 @@
   }
 
   /**
-   * Obfuscate email and assign href to email icon
-   */
-  function injectMailToButton() {
-    const getEmailButtonHtmlStr = function (link) {
-      return '<a href="mailto:' + link + '" aria-label="Email"><i class="fas fa-envelope fa-2x mx-2" aria-hidden="true"></i></a>';
-    }
-
-    // Email obfuscator script 2.1 by Tim Williams, University of Arizona
-    // Random encryption key feature coded by Andrew Moulden
-    // This code is freeware provided these four comment lines remain intact
-    // A wizard to generate this code is at http://www.jottings.com/obfuscator/
-    const coded = "Js0N@iJ96ZyNFv6JsyN6s.yNo"
-    const key = "oaIMb8y7e3dG4WRQEZYB0qlHiNkVSnrPtvjFCmhDwLKcp1A6UJ5O2zs9TfuXxg"
-    const shift = coded.length
-    let link = ""
-    for (let i = 0; i < coded.length; i++) {
-      if (key.indexOf(coded.charAt(i)) == -1) {
-        const ltr = coded.charAt(i)
-        link += (ltr)
-      }
-      else {
-        const ltr = (key.indexOf(coded.charAt(i)) - shift + key.length) % key.length
-        link += (key.charAt(ltr))
-      }
-    }
-
-    $('#social-links').prepend(getEmailButtonHtmlStr(link));
-  }
-
-  /**
    * Programatically add copyright message with current year
    */
   function injectCopyrightStatement() {
@@ -74,7 +44,6 @@
     // Add handlers after document is ready
     assignNavLinkClickHandlers();
     assignTimelineShowMoreHandler();
-    injectMailToButton();
     injectCopyrightStatement();
   });
 })();


### PR DESCRIPTION
Added contact form to GCL website - done with Netlify. Removed previous mailto: icon in footer
closes #51 

Contact form accepts name, email, and message and sends an email to info@girlscodelincoln.com and sends a slack message to #contact-form-subs channel on GCL slack workspace. Configuration for the contact an be found here: https://app.netlify.com/sites/girlscodelincoln/settings/forms. Netlify allows 100 messages per month for free. I don't anticipate we'll exceed this for awhile.

In the future we can add more fields such as why a person is emailing us for auto sorting (volunteer, donations, girl interested in club, etc) and also hit other external services with each submission such as automatically making Trello cards

Contact form on desktop:
![image](https://user-images.githubusercontent.com/22859824/52917553-821cbe00-32b2-11e9-9137-500c0bc584c7.png)

Contact form on iPad:
![image](https://user-images.githubusercontent.com/22859824/52917568-aa0c2180-32b2-11e9-99a9-63c1d6e79c04.png)

Contact form on iPhoneX:
![image](https://user-images.githubusercontent.com/22859824/52917575-c0b27880-32b2-11e9-843a-7a5e2338ad6c.png)

Contact form post submission (default netlify):
![image](https://user-images.githubusercontent.com/22859824/52917548-6e715780-32b2-11e9-9a49-5a6d05c3afa2.png)

Resulting email:
![image](https://user-images.githubusercontent.com/22859824/52917593-f9525200-32b2-11e9-9a67-af9f9fa9a80c.png)

Resulting slack message:
![image](https://user-images.githubusercontent.com/22859824/52917597-066f4100-32b3-11e9-8366-67d8dfb81f09.png)

