### PR TITLE
Add redirects for donate and merchandise links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@ ID = "girlscodelincoln.com"
   to = "https://www.gofundme.com/h9j5y-girls-code-lincoln/donate"
   status = 301
 [[redirects]]
-  from = "https://merchandise.girlscodelincoln.com/"
+  from = "https://girlscodelincoln.com/merchandise"
   to = "https://teespring.com/stores/girlscodelincoln"
   status = 301
 

--- a/src/index.html
+++ b/src/index.html
@@ -78,7 +78,7 @@
           <li class="nav-item d-none d-md-block">
             <a
               class="cta-btn nav-link font-weight-bold btn ml-lg-2"
-              href="https://www.gofundme.com/h9j5y-girls-code-lincoln/donate"
+              href="https://girlscodelincoln.com/donate"
               target="_blank" rel="noopener">
                 Donate
             </a>

--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@
       <!-- donate button to show on smaller screen widths - shows left of the navbar toggler -->
       <a
         class="cta-btn nav-link font-weight-bold btn btn-sm ml-auto mr-2 d-md-none"
-        href="https://www.gofundme.com/h9j5y-girls-code-lincoln/donate"
+        href="https://girlscodelincoln.com/donate"
         target="_blank" rel="noopener">
           Donate
       </a>
@@ -67,7 +67,7 @@
             <a class="nav-link" href="#sponsors-partners">Sponsors & Partners</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://merchandise.girlscodelincoln.com/" target="_blank" rel="noopener">
+            <a class="nav-link" href="https://girlscodelincoln.com/merchandise" target="_blank" rel="noopener">
               Merchandise
             </a>
           </li>


### PR DESCRIPTION
Via Netlify, redirect links. Will make it easier to share with others what our merchandise and donate links are.

`"https://girlscodelincoln.com/donate"` ➡ `"https://www.gofundme.com/h9j5y-girls-code-lincoln/donate"`
`"https://girlscodelincoln.com/merchandise"` ➡ `"https://teespring.com/stores/girlscodelincoln"`

closes #61 