### PR TITLE
Revert "Redirect donation page to Give to Lincoln (#146)"

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -1,4 +1,4 @@
-# /donate        https://secure.givelively.org/donate/girls-code-lincoln     302!
-/donate        https://www.givetolincoln.com/nonprofits/girls-code-lincoln 302!
+/donate        https://secure.givelively.org/donate/girls-code-lincoln     302!
+# /donate        https://www.givetolincoln.com/nonprofits/girls-code-lincoln 302!
 /merchandise   https://teespring.com/stores/girlscodelincoln               302!
 /shop          https://teespring.com/stores/girlscodelincoln               302!


### PR DESCRIPTION
Now that Give to Lincoln Day is over, direct donations back to our Give Lively donation page.

This reverts commit b147e3ae64439de4fe0e0fc403dbf320c137921b.